### PR TITLE
Remove numpy hard constraint for ann option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
         "scikit-learn",
         "numpy"
     ],
-    extras_require={'ann': ["numpy==1.21", "pynndescent"]},
+    extras_require={'ann': ["pynndescent"]},
     project_urls={
         "Repository": "https://github.com/ssarfraz/FINCH-Clustering",
         "Publication": "https://openaccess.thecvf.com/content_CVPR_2019/html/Sarfraz_Efficient_Parameter-Free_Clustering_Using_First_Neighbor_Relations_CVPR_2019_paper.html"


### PR DESCRIPTION
I have tried running both the example notebooks with `pynndescent>=0.5.13`.
My numpy version is: `numpy==2.2.5`.
- Basic_usage.ipynb
- Clustering_with_FINCH.ipynb
It seems to output the same outputs.
Perhaps there's no need to hardcode numpy requirement.
For your consideration. Thank you!